### PR TITLE
Xcode 27 compatibility but use CoreStoreError wrapper

### DIFF
--- a/Sources/DispatchQueue+CoreStore.swift
+++ b/Sources/DispatchQueue+CoreStore.swift
@@ -87,16 +87,11 @@ extension DispatchQueue {
     ) throws(CoreStoreError) -> T {
 
         do {
-
             return try self.sync { try autoreleasepool(invoking: closure) }
-        }
-        catch let error {
-
+        } catch let error {
             switch error {
-
             case let error as CoreStoreError:
                 throw error
-
             default:
                 throw CoreStoreError(error)
             }

--- a/Sources/DispatchQueue+CoreStore.swift
+++ b/Sources/DispatchQueue+CoreStore.swift
@@ -81,15 +81,6 @@ extension DispatchQueue {
 
         return self.sync { autoreleasepool(invoking: closure) }
     }
-
-    @nonobjc @inline(__always)
-    internal func cs_sync<T>(
-        _ closure: () throws(any Swift.Error) -> T
-    ) throws(any Swift.Error) -> T {
-
-        return try self.sync { try autoreleasepool(invoking: closure) }
-    }
-
     @nonobjc @inline(__always)
     internal func cs_sync<T>(
         _ closure: () throws(CoreStoreError) -> T
@@ -99,9 +90,16 @@ extension DispatchQueue {
 
             return try self.sync { try autoreleasepool(invoking: closure) }
         }
-        catch {
+        catch let error {
 
-            throw CoreStoreError(error)
+            switch error {
+
+            case let error as CoreStoreError:
+                throw error
+
+            default:
+                throw CoreStoreError(error)
+            }
         }
     }
 


### PR DESCRIPTION
basically very similar to #519 
same ambiguous error for `cs_sync` on Xcode 27 or Swift 6.4
just I think using preexisting wrapper `CoreStoreError(error)` is better
cc @JohnEstropia 