### PR TITLE
Fix 'occured' typo in error descriptions

### DIFF
--- a/Sources/CoreStoreError.swift
+++ b/Sources/CoreStoreError.swift
@@ -35,7 +35,7 @@ import CoreData
 public enum CoreStoreError: Error, CustomNSError, Hashable {
     
     /**
-     A failure occured because of an unknown error.
+     A failure occurred because of an unknown error.
      */
     case unknown
     
@@ -296,7 +296,7 @@ public let CoreStoreErrorDomain = "com.corestore.error"
 public enum CoreStoreErrorCode: Int {
     
     /**
-     A failure occured because of an unknown error.
+     A failure occurred because of an unknown error.
      */
     case unknownError
     

--- a/Sources/DataStack+Migration.swift
+++ b/Sources/DataStack+Migration.swift
@@ -106,7 +106,7 @@ extension DataStack {
      ```
      - parameter storage: the local storage
      - parameter completion: the closure to be executed on the main queue when the process completes, either due to success or failure. The closure's `SetupResult` argument indicates the result. Note that the `LocalStorage` associated to the `SetupResult.success` may not always be the same instance as the parameter argument if a previous `LocalStorage` was already added at the same URL and with the same configuration.
-     - returns: a `Progress` instance if a migration has started, or `nil` if either no migrations are required or if a failure occured.
+     - returns: a `Progress` instance if a migration has started, or `nil` if either no migrations are required or if a failure occurred.
      */
     public func addStorage<T: LocalStorage>(
         _ storage: T,


### PR DESCRIPTION
Minor doc-comment typo: `occured` should be `occurred`. Three occurrences across `Sources/CoreStoreError.swift` and `Sources/DataStack+Migration.swift`. No code change.
